### PR TITLE
Entity Selection and Print Log for each Entity

### DIFF
--- a/behavior_tree_config/agent.txt
+++ b/behavior_tree_config/agent.txt
@@ -74,7 +74,8 @@ tree FollowPathAndAvoid = Sequence {
                 TryReverse
             }
         } else {
-            Print(input <- "found path: {}", arg0 <- path)
+            DigestPath (input <- path, output -> digest_path)
+            Print(input <- "found path: {}", arg0 <- digest_path)
         }
     }
     if (HasPath) {

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -236,6 +236,46 @@ impl SwarmRsApp {
                 )
             });
         });
+
+        ui.group(|ui| {
+            ui.heading("Selected entity");
+
+            ui.label(format!("Id: {:?}", self.app_data.selected_entity));
+
+            let entity = self.app_data.selected_entity.and_then(|id| {
+                self.app_data
+                    .game
+                    .entities
+                    .iter()
+                    .filter_map(|entity| entity.try_borrow().ok())
+                    .find(|entity| entity.get_id() == id)
+            });
+
+            ui.label(match &entity {
+                Some(entity) => {
+                    format!(
+                        "Health: {} / {}",
+                        entity.get_health(),
+                        entity.get_max_health()
+                    )
+                }
+                None => "Health: ? / ?".to_owned(),
+            });
+
+            ui.label(match &entity {
+                Some(entity) => format!("Target: {:?}", entity.get_target()),
+                None => "Target: ?".to_owned(),
+            });
+
+            ui.label(match &entity {
+                Some(entity) => format!(
+                    "Resource: {} / {}",
+                    entity.resource(),
+                    entity.max_resource()
+                ),
+                None => "Resource: ? / ?".to_owned(),
+            });
+        });
     }
 
     fn show_editor(

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -245,30 +245,35 @@ impl SwarmRsApp {
                     .find(|entity| entity.get_id() == id)
             });
 
-            ui.label(match &entity {
-                Some(entity) => {
-                    format!(
-                        "Health: {} / {}",
-                        entity.get_health(),
-                        entity.get_max_health()
-                    )
-                }
-                None => "Health: ? / ?".to_owned(),
-            });
+            match &entity {
+                Some(entity) => ui.label(format!("Team: {:?}", entity.get_team())),
+                None => ui.label("Team: ?"),
+            };
 
-            ui.label(match &entity {
-                Some(entity) => format!("Target: {:?}", entity.get_target()),
-                None => "Target: ?".to_owned(),
-            });
+            match &entity {
+                Some(entity) => ui.label(format!(
+                    "Health: {} / {}",
+                    entity.get_health(),
+                    entity.get_max_health()
+                )),
+                None => ui.label("Health: ? / ?"),
+            };
 
-            ui.label(match &entity {
-                Some(entity) => format!(
+            match &entity {
+                Some(entity) => ui.label(format!("Target: {:?}", entity.get_target())),
+                None => ui.label("Target: ?"),
+            };
+
+            match &entity {
+                Some(entity) => ui.label(format!(
                     "Resource: {} / {}",
                     entity.resource(),
                     entity.max_resource()
-                ),
-                None => "Resource: ? / ?".to_owned(),
-            });
+                )),
+                None => ui.label("Resource: ? / ?"),
+            };
+
+            ui.label("Print log:");
 
             egui::ScrollArea::vertical()
                 .always_show_scroll(true)

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -121,9 +121,7 @@ impl SwarmRsApp {
             "Paused",
         ));
 
-        ui.group(|ui| {
-            ui.heading("New game options");
-
+        ui.collapsing("New game options", |ui| {
             if ui.button("New game").clicked() {
                 let params = BoardParams {
                     shape: (self.xs, self.ys),
@@ -168,9 +166,7 @@ impl SwarmRsApp {
             });
         });
 
-        ui.group(|ui| {
-            ui.heading("View options");
-
+        ui.collapsing("View options", |ui| {
             ui.horizontal(|ui| {
                 ui.add(egui::Checkbox::new(&mut self.app_data.path_visible, "Path"));
 
@@ -209,9 +205,7 @@ impl SwarmRsApp {
             ui.add(egui::Checkbox::new(&mut self.show_labels, "Label image"));
         });
 
-        ui.group(|ui| {
-            ui.heading("Debug output");
-
+        ui.collapsing("Debug output", |ui| {
             let game = &self.app_data.game;
 
             ui.label(format!("Scale: {:.06}", self.app_data.scale));
@@ -275,6 +269,29 @@ impl SwarmRsApp {
                 ),
                 None => "Resource: ? / ?".to_owned(),
             });
+
+            egui::ScrollArea::vertical()
+                .always_show_scroll(true)
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    let mut source = entity
+                        .map(|entity| {
+                            entity
+                                .log_buffer()
+                                .iter()
+                                .fold("".to_owned(), |acc, cur| acc + "\n" + cur)
+                        })
+                        .unwrap_or_else(|| "".to_owned());
+                    ui.add_enabled(
+                        false,
+                        egui::TextEdit::multiline(&mut source)
+                            .font(egui::TextStyle::Monospace)
+                            .code_editor()
+                            .desired_rows(10)
+                            .lock_focus(true)
+                            .desired_width(f32::INFINITY),
+                    );
+                });
         });
     }
 

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -47,7 +47,7 @@ impl SwarmRsApp {
                 delta: input.pointer.delta(),
                 interact_pos: Point2::new(interact_pos.x as f64, interact_pos.y as f64),
                 hover_pos: input.pointer.hover_pos(),
-                clicked: input.pointer.primary_clicked(),
+                clicked: input.pointer.primary_released(),
             }
         };
 

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 pub struct AppData {
     pub game: Game,
     pub game_params: GameParams,
+    pub(crate) selected_entity: Option<usize>,
     pub origin: [f64; 2],
     pub scale: f64,
     pub message: String,
@@ -50,6 +51,7 @@ impl AppData {
         Self {
             game,
             game_params,
+            selected_entity: None,
             origin: [0., 0.],
             scale,
             message: "".to_string(),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -182,6 +182,10 @@ impl Agent {
         self.health as f64 / self.class.health() as f64
     }
 
+    pub(crate) fn get_max_health(&self) -> u32 {
+        self.class.health()
+    }
+
     /// Check collision in qtree bounding boxes
     pub(crate) fn qtree_collision(
         ignore: Option<usize>,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,9 +19,9 @@ use self::{
     motion::{MotionCommandResult, OrientToResult},
 };
 use crate::{
-    behavior_tree_adapt::{BehaviorTree, GetIdCommand, GetResource},
+    behavior_tree_adapt::{BehaviorTree, GetIdCommand, GetResource, PrintCommand},
     collision::{aabb_intersects, CollisionShape, Obb},
-    entity::Entity,
+    entity::{Entity, MAX_LOG_ENTRIES},
     game::is_passable_at,
     game::{Board, Game, Profiler, Resource},
     measure_time,
@@ -95,6 +95,7 @@ pub struct Agent {
     last_state: Option<AgentState>,
     behavior_tree: Option<BehaviorTree>,
     blackboard: Blackboard,
+    log_buffer: VecDeque<String>,
 }
 
 const AGENT_SCALE: f64 = 1.;
@@ -152,6 +153,7 @@ impl Agent {
             last_state: None,
             behavior_tree: Some(tree),
             blackboard: Blackboard::new(),
+            log_buffer: VecDeque::new(),
         })
     }
 
@@ -184,6 +186,10 @@ impl Agent {
 
     pub(crate) fn get_max_health(&self) -> u32 {
         self.class.health()
+    }
+
+    pub(crate) fn log_buffer(&self) -> &VecDeque<String> {
+        &self.log_buffer
     }
 
     /// Check collision in qtree bounding boxes
@@ -544,6 +550,11 @@ impl Agent {
             let mut process = |f: &dyn std::any::Any| {
                 if f.downcast_ref::<GetIdCommand>().is_some() {
                     return Some(Box::new(self.id) as Box<dyn std::any::Any>);
+                } else if let Some(s) = f.downcast_ref::<PrintCommand>() {
+                    self.log_buffer.push_back(s.0.clone());
+                    while MAX_LOG_ENTRIES < self.log_buffer.len() {
+                        self.log_buffer.pop_front();
+                    }
                 } else if f.downcast_ref::<GetResource>().is_some() {
                     return Some(Box::new(self.resource));
                 } else if let Some(com) = f.downcast_ref::<DriveCommand>() {

--- a/src/behavior_tree_adapt.rs
+++ b/src/behavior_tree_adapt.rs
@@ -90,6 +90,8 @@ impl BehaviorNode for GeNode {
     }
 }
 
+pub(crate) struct PrintCommand(pub String);
+
 /// A node with string output with interpolation.
 struct PrintNode;
 
@@ -137,6 +139,7 @@ impl BehaviorNode for PrintNode {
             } else {
                 println!("PrintNode(?): {result:?}");
             }
+            arg(&PrintCommand(result));
             BehaviorResult::Success
         } else {
             BehaviorResult::Fail

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 use std::{cell::RefCell, collections::VecDeque};
 
+pub(crate) const MAX_LOG_ENTRIES: usize = 100;
+
 #[derive(Debug)]
 pub enum Entity {
     Agent(Agent),
@@ -208,6 +210,13 @@ impl Entity {
         match self {
             Entity::Agent(agent) => agent.resource = (agent.resource - resource).max(0),
             Entity::Spawner(spawner) => spawner.resource = (spawner.resource - resource).max(0),
+        }
+    }
+
+    pub fn log_buffer(&self) -> &VecDeque<String> {
+        match self {
+            Entity::Agent(agent) => agent.log_buffer(),
+            Entity::Spawner(spawner) => spawner.log_buffer(),
         }
     }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -4,7 +4,7 @@ use crate::{
     collision::CollisionShape,
     game::Game,
     qtree::QTreePathNode,
-    spawner::{Spawner, SPAWNER_MAX_RESOURCE},
+    spawner::{Spawner, SPAWNER_MAX_HEALTH, SPAWNER_MAX_RESOURCE},
 };
 use std::{cell::RefCell, collections::VecDeque};
 
@@ -131,6 +131,20 @@ impl Entity {
         match self {
             Entity::Agent(agent) => agent.get_shape().to_aabb(),
             Entity::Spawner(spawner) => Spawner::collision_shape(spawner.pos).to_aabb(),
+        }
+    }
+
+    pub fn get_health(&self) -> u32 {
+        match self {
+            Entity::Agent(agent) => agent.health,
+            Entity::Spawner(spawner) => spawner.health,
+        }
+    }
+
+    pub fn get_max_health(&self) -> u32 {
+        match self {
+            Entity::Agent(agent) => agent.get_max_health(),
+            Entity::Spawner(_) => SPAWNER_MAX_HEALTH,
         }
     }
 

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use std::cell::RefCell;
 
-const SPAWNER_MAX_HEALTH: u32 = 1000;
+pub(crate) const SPAWNER_MAX_HEALTH: u32 = 1000;
 pub(crate) const SPAWNER_MAX_RESOURCE: i32 = 1000;
 pub(crate) const SPAWNER_RADIUS: f64 = 1.0;
 


### PR DESCRIPTION
It's so hard to debug behavior tree logic because there is no proper debugger. I plan to make one at some point, but right now a convenient feature is to print each Entity's log (output by `Print` node) in a log window.

You can select an Entity by clicking on it. A selected Entity will be highlighted by white, and its brief information is shown at the bottom of side panel.  The log is also shown at the bottom of the side panel.

![image](https://user-images.githubusercontent.com/2798715/219910081-06e3f2b7-f4df-4e5d-aa7d-905854b73acb.png)

See in a video:

https://user-images.githubusercontent.com/2798715/219910021-fe983206-c1ce-475c-ad6d-e5c772422369.mp4

The log is kept until 100 entries. If it outputs more than 100 entries, the oldest ones will be deleted from the log.

# `Print` node

The `Print` behavior node is a convenience feature to print whatever given by the parameters. It has limited capability of formatting, so you can pass up to 2 variables as the interploated values.

```
Print (input <- "Hello, {} and {}!", arg0 <- "Alice", arg1 <- "Bob")
```

The string will be printed on the terminal, but it's messy and hard to see, especially when there are a lot of Entities.
Print log for each Entity will limit the focus to that specific Entity, making it much easier to read.

Also, Wasm doesn't have terminal (it's not redirected to `console.log`). So it is the only way to debug on Wasm app.


# No Druid support

As Druid is being discontinued, this feature is not implemented in Druid GUI app. Even if I did, the log won't scroll, so it wouldn't be so helpful.