### PR TITLE
Replan path periodically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,8 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "behavior-tree-lite"
-version = "0.2.2"
-source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.2.2#f12c6601ab0477b21989dab4c929a46c013c18b5"
+version = "0.2.3"
+source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.2.3#4ec888a9189560de6b8d3b79a76384f72aea3238"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ getrandom = { version = "0.2.8", features = ["js"] }
 [dependencies.behavior-tree-lite]
 # path = "../rusty-behavior-tree-lite"
 git = "https://github.com/msakuta/rusty-behavior-tree-lite"
-tag = "v0.2.2"
+tag = "v0.2.3"
 # commit = "96559722c23d7a637879192f635a785b071d6fb1"
 # branch = "master"
 

--- a/behavior_tree_config/agent.txt
+++ b/behavior_tree_config/agent.txt
@@ -78,6 +78,17 @@ tree FollowPathAndAvoid = Sequence {
             Print(input <- "found path: {}", arg0 <- digest_path)
         }
     }
+
+    # Try to search path every 50 ticks, even if we already have one, to update potentially moving target or obstacles
+    Throttle (time <- "100") {
+        if (!FindPath (target <- target_pos, path -> path, fail_reason -> failReason)) {
+            Print (input <- "Failed to find path! reason: {}", arg0 <- failReason)
+        } else {
+            DigestPath (input <- path, output -> digest_path)
+            Print (input <- "found path: {}", arg0 <- digest_path)
+        }
+    }
+
     if (HasPath) {
         #SimpleAvoidance
         if (!FollowPath) {

--- a/behavior_tree_config/agent.txt
+++ b/behavior_tree_config/agent.txt
@@ -67,26 +67,12 @@ tree TryReverse = ReactiveSequence {
 tree FollowPathAndAvoid = Sequence {
     TargetPos (pos -> target_pos)
     if (!HasPath) {
-        if (!FindPath (target <- target_pos, path -> path, fail_reason -> failReason)) {
-            Print (input <- "Failed to find path! reason: {}", arg0 <- failReason)
-            # If path finding failed because the start is blocked, try back out
-            if (StringEq(lhs <- failReason, rhs <- "StartBlocked")) {
-                TryReverse
-            }
-        } else {
-            DigestPath (input <- path, output -> digest_path)
-            Print(input <- "found path: {}", arg0 <- digest_path)
-        }
+        FindPathPlan (try_reverse <- "true")
     }
 
     # Try to search path every 50 ticks, even if we already have one, to update potentially moving target or obstacles
     Throttle (time <- "100") {
-        if (!FindPath (target <- target_pos, path -> path, fail_reason -> failReason)) {
-            Print (input <- "Failed to find path! reason: {}", arg0 <- failReason)
-        } else {
-            DigestPath (input <- path, output -> digest_path)
-            Print (input <- "found path: {}", arg0 <- digest_path)
-        }
+        FindPathPlan (try_reverse <- "false")
     }
 
     if (HasPath) {
@@ -98,6 +84,19 @@ tree FollowPathAndAvoid = Sequence {
             FindPath (target <- target_pos)
             #AvoidancePlan
         }
+    }
+}
+
+tree FindPathPlan(in try_reverse) = Sequence {
+    TargetPos (pos -> target_pos)
+    if (!FindPath (target <- target_pos, path -> path, fail_reason -> failReason) && !FindPath (target <- target_pos, ignore_obstacles <- "true", path -> path, fail_reason -> failReason)) {
+        Print (input <- "Failed to find path! reason: {}", arg0 <- failReason)
+        if (IsTrue(input <- try_reverse) && StringEq(lhs <- failReason, rhs <- "StartBlocked")) {
+            TryReverse
+        }
+    } else {
+        DigestPath (input <- path, output -> digest_path)
+        Print (input <- "found path: {}", arg0 <- digest_path)
     }
 }
 

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -12,7 +12,7 @@ use swarm_rs::{
 use super::SwarmRsApp;
 
 /// Transform a vector (delta). Equivalent to `(m * v.extend(0.)).truncate()`.
-fn transform_vector(m: &Matrix3<f64>, v: impl Into<Vector2<f64>>) -> Vector2<f64> {
+fn _transform_vector(m: &Matrix3<f64>, v: impl Into<Vector2<f64>>) -> Vector2<f64> {
     // Transform trait is implemented for both Point2 and Point3, so we need to repeat fully qualified method call
     <Matrix3<f64> as Transform<Point2<f64>>>::transform_vector(m, v.into())
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -612,7 +612,7 @@ impl Agent {
                         _ => (),
                     }
                 } else if let Some(com) = f.downcast_ref::<FindPathCommand>() {
-                    let found_path = self.find_path(com.0, game);
+                    let found_path = self.find_path(com, game);
                     return Some(Box::new(found_path));
                 } else if let Some(cmd) = f.downcast_ref::<FollowPathCommand>() {
                     command = Some(Command::FollowPath(*cmd));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -551,10 +551,7 @@ impl Agent {
                 if f.downcast_ref::<GetIdCommand>().is_some() {
                     return Some(Box::new(self.id) as Box<dyn std::any::Any>);
                 } else if let Some(s) = f.downcast_ref::<PrintCommand>() {
-                    self.log_buffer.push_back(s.0.clone());
-                    while MAX_LOG_ENTRIES < self.log_buffer.len() {
-                        self.log_buffer.pop_front();
-                    }
+                    self.log(s.0.clone());
                 } else if f.downcast_ref::<GetResource>().is_some() {
                     return Some(Box::new(self.resource));
                 } else if let Some(com) = f.downcast_ref::<DriveCommand>() {
@@ -724,6 +721,13 @@ impl Agent {
         //     self.path = vec![];
         // }
         self.cooldown = (self.cooldown - 1.).max(0.);
+    }
+
+    fn log(&mut self, msg: String) {
+        self.log_buffer.push_back(msg);
+        while MAX_LOG_ENTRIES < self.log_buffer.len() {
+            self.log_buffer.pop_front();
+        }
     }
 }
 

--- a/src/agent/find_path.rs
+++ b/src/agent/find_path.rs
@@ -1,8 +1,13 @@
+use std::cell::Cell;
+
+use cgmath::{MetricSpace, Vector2};
+
 use super::{behavior_nodes::FindPathCommand, Agent, AgentTarget, AGENT_HALFLENGTH};
 use crate::{
     game::Game,
     measure_time,
     qtree::{qtree::PathFindError, QTreePathNode},
+    CellState,
 };
 
 impl Agent {
@@ -38,11 +43,60 @@ impl Agent {
         game.path_find_profiler.get_mut().add(time);
         self.search_tree = Some(search_tree);
         match found_path {
-            Ok(path) => {
+            Ok(mut path) => {
+                self.shortcut_path(&mut path, game);
                 self.path = path.clone();
                 Ok(path)
             }
             Err(err) => Err(err),
+        }
+    }
+
+    /// Shortcut last few nodes if it's still visible. It won't attempt to shortcut the whole path
+    /// since line-of-sight check can be expensive.
+    fn shortcut_path(&mut self, path: &mut Vec<QTreePathNode>, game: &Game) {
+        const MAX_SHORTCUT_DISTANCE: f64 = 10.;
+        let current = self.pos;
+        let ignore_id = self.id;
+        let before_num = path.len();
+        let checks = Cell::new(0);
+        for _ in 0..5 {
+            if path.len() < 3 {
+                break;
+            }
+            let second_last = path[path.len() - 2].pos;
+
+            // Don't attempt to shortcut too far away
+            if MAX_SHORTCUT_DISTANCE.powf(2.)
+                < Vector2::from(second_last).distance2(Vector2::from(current))
+            {
+                break;
+            }
+            let ret = game.qtree.get_cache_map().is_position_visible(
+                |cell_state| {
+                    checks.set(checks.get() + 1);
+                    match cell_state {
+                        CellState::Obstacle => true,
+                        CellState::Occupied(id) => id != ignore_id,
+                        CellState::Free => false,
+                        _ => false,
+                    }
+                },
+                current,
+                second_last,
+            );
+            if ret {
+                path.pop();
+            } else {
+                break;
+            }
+        }
+        let after_num = path.len();
+        if before_num != after_num {
+            // self.log(format!(
+            //     "Path shortcut from {before_num} to {after_num} checks: {}",
+            //     checks.get()
+            // ));
         }
     }
 }

--- a/src/qtree.rs
+++ b/src/qtree.rs
@@ -133,12 +133,12 @@ impl QTreeSearcher {
 
     pub(crate) fn path_find(
         &self,
-        ignore_id: &[usize],
+        ignore: impl Fn(usize) -> bool,
         start: [f64; 2],
         end: [f64; 2],
         goal_radius: f64,
     ) -> (Result<QTreePath, PathFindError>, SearchTree) {
-        self.qtree.path_find(ignore_id, start, end, goal_radius)
+        self.qtree.path_find(ignore, start, end, goal_radius)
     }
 
     pub fn check_collision(&self, aabb: &Aabb) -> bool {

--- a/src/qtree/cache_map.rs
+++ b/src/qtree/cache_map.rs
@@ -1,3 +1,7 @@
+use cgmath::{MetricSpace, Vector2};
+
+use crate::agent::interpolation;
+
 use super::{CellState, Rect};
 use std::{
     collections::HashMap,
@@ -171,5 +175,30 @@ impl CacheMap {
         } else {
             CellState::Obstacle
         }
+    }
+
+    pub fn is_position_visible(
+        &self,
+        collide: impl Fn(CellState) -> bool,
+        source: [f64; 2],
+        target: [f64; 2],
+    ) -> bool {
+        const INTERPOLATE_INTERVAL: f64 = 1.;
+        let distance = Vector2::from(source).distance(Vector2::from(target));
+        if distance < INTERPOLATE_INTERVAL {
+            return false;
+        }
+        !interpolation::interpolate(source, target, INTERPOLATE_INTERVAL, |point| {
+            if point[0] < 0.
+                || self.size <= point[0] as usize
+                || point[1] < 0.
+                || self.size <= point[1] as usize
+            {
+                true
+            } else {
+                let cell = self.get([point[0] as i32, point[1] as i32]);
+                collide(cell)
+            }
+        })
     }
 }

--- a/src/qtree/qtree.rs
+++ b/src/qtree/qtree.rs
@@ -286,7 +286,7 @@ impl Display for PathFindError {
 impl QTree {
     pub(crate) fn path_find(
         &self,
-        ignore_id: &[usize],
+        ignore: impl Fn(usize) -> bool,
         start: [f64; 2],
         end: [f64; 2],
         goal_radius: f64,
@@ -296,7 +296,7 @@ impl QTree {
         };
         let blocked = |state| match state {
             CellState::Obstacle => true,
-            CellState::Occupied(id) => !ignore_id.iter().any(|i| *i == id),
+            CellState::Occupied(id) => !ignore(id),
             _ => false,
         };
         if blocked(start_found.1) {


### PR DESCRIPTION
# Path replanning

Path finding needs an improvement. After a path has been found, the situation can change, and by the time the agent arrives at the target, it's too late (resources may be taken or the enemy may have been moved). In order to follow the change in the situation, we want to keep updating the path, even if the previous path was valid when it was found.

It feels stupid when a Fighter tries to kill another agent, but arrives at an empty space.

https://user-images.githubusercontent.com/2798715/219934755-520784b4-5f19-4cad-aa5f-3684121bdcfc.mp4


However, it is not cheap to find a path every tick. So we want to reduce the frequency of this regular update by a new node, `Throttle`. It is a decorator node that runs the child node every once in a while. The frequency to call the inner node can be adjusted by `time` argument.

```
Throttle (time <- "100") {
    FindPathPlan (try_reverse <- "false")
}
```

# Shortcutting path

We also shortcut the first few nodes of the path if the line of sight is clear. Unless we do this, we sometimes get a path like below, making the agent turn around unnecessarily in empty space. It happens because the agent itself divides the quad tree, so the path nodes become fine grained. However, it is not necessary to have high resolution path in this case, because the area is empty except the agent itself.

![image](https://user-images.githubusercontent.com/2798715/219934842-f82cf55e-ea1a-4820-9cfd-18a453020bb8.png)

This issue existed before replanning feature, but it becomes more visible because path planning happens more frequently in empty area.

Actually, the shortcutting logic seems not perfect. It still happens sometimes and I don't know exactly why.
