### PR TITLE
Statistics display

### DIFF
--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -230,6 +230,23 @@ impl SwarmRsApp {
             ui.add(egui::Checkbox::new(&mut self.show_labels, "Label image"));
         });
 
+        ui.collapsing("Statistics", |ui| {
+            let game = &self.app_data.game;
+
+            ui.horizontal(|ui| {
+                for team in 0..=1 {
+                    ui.vertical(|ui| {
+                        ui.group(|ui| {
+                            ui.label(["Green team", "Red team"][team]);
+                            ui.label(format!("Spawned: {}", game.stats[team].spawned));
+                            ui.label(format!("Kills: {}", game.stats[team].kills));
+                            ui.label(format!("Wins: {}", game.stats[team].wins));
+                        });
+                    });
+                }
+            });
+        });
+
         ui.collapsing("Debug output", |ui| {
             let game = &self.app_data.game;
 

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -231,7 +231,11 @@ impl SwarmRsApp {
         });
 
         ui.collapsing("Statistics", |ui| {
-            let game = &self.app_data.game;
+            let game = &mut self.app_data.game;
+
+            if ui.button("Reset").clicked() {
+                game.stats = Default::default();
+            }
 
             ui.horizontal(|ui| {
                 for team in 0..=1 {

--- a/src/game.rs
+++ b/src/game.rs
@@ -103,6 +103,13 @@ pub struct TeamConfig {
     pub spawner_source: Rc<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TeamStats {
+    pub spawned: usize,
+    pub kills: usize,
+    pub wins: usize,
+}
+
 #[cfg_attr(feature = "druid", derive(Data))]
 #[derive(Clone)]
 pub struct GameParams {
@@ -147,6 +154,7 @@ pub struct Game {
     pub path_find_profiler: RefCell<Profiler>,
     pub agent_count: usize,
     pub(crate) teams: [TeamConfig; 2],
+    pub stats: [TeamStats; 2],
     pub qtree: QTreeSearcher,
 }
 
@@ -193,6 +201,7 @@ impl Game {
             path_find_profiler: RefCell::new(Profiler::new()),
             agent_count: 3,
             teams: Default::default(),
+            stats: Default::default(),
             qtree,
         }
     }
@@ -499,6 +508,7 @@ impl Game {
                     {
                         println!("Spawning agent {class:?}");
                         entities.push(RefCell::new(agent));
+                        self.stats[team].spawned += 1;
                         if let Some(spawner) = entities
                             .iter_mut()
                             .find(|ent| ent.borrow().get_id() == spawner)

--- a/src/game.rs
+++ b/src/game.rs
@@ -530,6 +530,7 @@ impl Game {
         {
             let agents = &self.entities;
             let mut temp_ents = std::mem::take(&mut self.temp_ents);
+            let mut kills = [0usize; 2];
             self.bullets = self
                 .bullets
                 .iter()
@@ -560,6 +561,7 @@ impl Game {
                                 temp_ents.push(temp_ent);
                                 if agent.damage(bullet.damage) {
                                     agent.set_active(false);
+                                    kills[bullet.team] += 1;
                                     println!("Entity {} is being killed", agent.get_id());
                                 }
                                 return None;
@@ -577,6 +579,10 @@ impl Game {
                 .into_iter()
                 .filter_map(|mut ent| if ent.update() { Some(ent) } else { None })
                 .collect();
+
+            for team in 0..self.stats.len() {
+                self.stats[team].kills += kills[team];
+            }
         }
 
         let (_, timer) = measure_time(|| {

--- a/src/game.rs
+++ b/src/game.rs
@@ -669,7 +669,9 @@ impl Game {
                 .any(|agent| !agent.borrow().is_agent() && agent.borrow().get_team() == team)
             {
                 self.entities = entities;
-                return UpdateResult::TeamWon((team + 1) % 2);
+                let won_team = (team + 1) % 2;
+                self.stats[won_team].wins += 1;
+                return UpdateResult::TeamWon(won_team);
             }
         }
         self.entities = entities;


### PR DESCRIPTION
Show statististics on the right panel.

![image](https://user-images.githubusercontent.com/2798715/220975300-7ee25708-59cc-4e84-9f78-bb81387eaf47.png)

Now that we have different AIs on each team, we want to see the performance of them. However, this game involves a lot of randomness and luck, so we need to accumulate many matches to evaluate performance. The statistics should indicate the performance with enough samples.

We could come up with many more interesting metrics or fansy charts, but right now we have

* Spawned: the number of spawned agents. It roughly indicates resource acquisition performance.
* Kills: the number of killed agents of the opponent. It indicates combat performance.
* Wins: the number of wins (killed enemy spawner). It indicates the total performance to achieve the goal.