### PR TITLE
Restore behavior tree from previous session

### DIFF
--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -515,7 +515,13 @@ impl SwarmRsApp {
                                             BtType::Spawner => &mut bt_source.spawner,
                                         } = item.to_owned();
                                     }
-                                    Err(_e) => (),//self.app_data.set_message(e),
+                                    Err(e) => {
+                                        if !e.detail.is_empty() {
+                                            self.app_data.set_message_with_payload(e.title, e.detail);
+                                        } else {
+                                            self.app_data.set_message(e.title);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -3,7 +3,7 @@ mod paint_game;
 use std::{path::Path, rc::Rc};
 
 use crate::{
-    app_data::{AppData, BTEditor},
+    app_data::{AppData, BtType},
     bg_image::BgImage,
 };
 use cgmath::Matrix3;
@@ -136,7 +136,7 @@ impl SwarmRsApp {
                     vfs.as_ref(),
                     &res.bt_source_file[team].agent,
                     team,
-                    BTEditor::Agent,
+                    BtType::Agent,
                 );
             }
             res.app_data.vfs = Some(vfs);
@@ -385,12 +385,12 @@ impl SwarmRsApp {
             for (team, color) in team_colors.into_iter().enumerate() {
                 ui.radio_value(
                     &mut self.app_data.selected_bt,
-                    (team, BTEditor::Agent),
+                    (team, BtType::Agent),
                     RichText::new("Agent").color(color),
                 );
                 ui.radio_value(
                     &mut self.app_data.selected_bt,
-                    (team, BTEditor::Spawner),
+                    (team, BtType::Spawner),
                     RichText::new("Spawner").color(color),
                 );
             }
@@ -497,8 +497,8 @@ impl SwarmRsApp {
                                         let bt_source = &mut self.bt_source_file
                                             [self.app_data.selected_bt.0];
                                         *match self.app_data.selected_bt.1 {
-                                            BTEditor::Agent => &mut bt_source.agent,
-                                            BTEditor::Spawner => &mut bt_source.spawner,
+                                            BtType::Agent => &mut bt_source.agent,
+                                            BtType::Spawner => &mut bt_source.spawner,
                                         } = item.to_owned();
                                     }
                                     Err(_e) => (),//self.app_data.set_message(e),

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -12,7 +12,7 @@ use swarm_rs::vfs::FileVfs;
 use std::rc::Rc;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum BTEditor {
+pub enum BtType {
     Agent,
     Spawner,
 }
@@ -39,7 +39,7 @@ pub struct AppData {
     pub(crate) entity_label_visible: bool,
     pub(crate) entity_trace_visible: bool,
     pub(crate) global_render_time: f64,
-    pub(crate) selected_bt: (usize, BTEditor),
+    pub(crate) selected_bt: (usize, BtType),
     pub(crate) new_file_name: String,
     pub(crate) current_file_name: String,
     /// This buffer is not yet applied to the game.
@@ -110,7 +110,7 @@ impl AppData {
             entity_label_visible: true,
             entity_trace_visible: false,
             global_render_time: 0.,
-            selected_bt: (0, BTEditor::Agent),
+            selected_bt: (0, BtType::Agent),
             new_file_name: "agent.txt".to_owned(),
             current_file_name: "".to_owned(),
             bt_buffer: "".to_owned(),
@@ -195,7 +195,7 @@ impl AppData {
         vfs: &dyn Vfs,
         file_name: &str,
         team: usize,
-        bt_type: BTEditor,
+        bt_type: BtType,
     ) -> Result<(), String> {
         let content = vfs.get_file(file_name)?;
 
@@ -203,8 +203,8 @@ impl AppData {
             .try_load_behavior_tree(Rc::new(content), &mut |params: &mut GameParams| {
                 let tc = &mut params.teams[team];
                 match bt_type {
-                    BTEditor::Agent => &mut tc.agent_source,
-                    BTEditor::Spawner => &mut tc.spawner_source,
+                    BtType::Agent => &mut tc.agent_source,
+                    BtType::Spawner => &mut tc.spawner_source,
                 }
             })
             .is_ok()

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -17,6 +17,8 @@ pub enum BtType {
     Spawner,
 }
 
+pub type BtTarget = (usize, BtType);
+
 pub struct AppData {
     pub game: Game,
     pub game_params: GameParams,
@@ -39,7 +41,7 @@ pub struct AppData {
     pub(crate) entity_label_visible: bool,
     pub(crate) entity_trace_visible: bool,
     pub(crate) global_render_time: f64,
-    pub(crate) selected_bt: (usize, BtType),
+    pub(crate) selected_bt: BtTarget,
     pub(crate) new_file_name: String,
     pub(crate) current_file_name: String,
     /// This buffer is not yet applied to the game.
@@ -194,8 +196,7 @@ impl AppData {
         &mut self,
         vfs: &dyn Vfs,
         file_name: &str,
-        team: usize,
-        bt_type: BtType,
+        (team, bt_type): BtTarget,
     ) -> Result<(), String> {
         let content = vfs.get_file(file_name)?;
 


### PR DESCRIPTION
When the application is closed and opened again, it will restore the previous session's behavior tree. It is convenient, but it didn't actually reflect to the entities until you press "Apply".

In other words, the selection of the behavior tree in this virtual filesystem after the application was restarted wasn't showing actual behavior tree.

![image](https://user-images.githubusercontent.com/2798715/221403208-2cf05b40-5ae6-4124-aaf8-78d28e6a0d13.png)

This is counterintuitive, so we would like to fix it.