### PR TITLE
Integrated behavior tree graphical editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "behavior-tree-lite"
 version = "0.2.5"
-source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.2.5#a979e4dde55ed9c342b08f0d27856f75e96fd90b"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,8 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "behavior-tree-lite"
-version = "0.2.5"
+version = "0.3.0"
+source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.3.0#9ecd1071ece77512d3096a36a1b4cf828c5680d5"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2.8", features = ["js"] }
 
 [dependencies.behavior-tree-lite]
-# path = "../rusty-behavior-tree-lite"
-git = "https://github.com/msakuta/rusty-behavior-tree-lite"
-tag = "v0.2.5"
+path = "../rusty-behavior-tree-lite"
+# git = "https://github.com/msakuta/rusty-behavior-tree-lite"
+# tag = "v0.2.5"
 # commit = "96559722c23d7a637879192f635a785b071d6fb1"
 # branch = "master"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2.8", features = ["js"] }
 
 [dependencies.behavior-tree-lite]
-path = "../rusty-behavior-tree-lite"
-# git = "https://github.com/msakuta/rusty-behavior-tree-lite"
-# tag = "v0.2.5"
+# path = "../rusty-behavior-tree-lite"
+git = "https://github.com/msakuta/rusty-behavior-tree-lite"
+tag = "v0.3.0"
 # commit = "96559722c23d7a637879192f635a785b071d6fb1"
 # branch = "master"
 

--- a/behavior_tree_config/green/agent.btc
+++ b/behavior_tree_config/green/agent.btc
@@ -28,10 +28,12 @@ tree main = Sequence {
 tree Fight = Sequence {
     var isTargetFog
     Throttle (time <- "100") {
-        SetBool (value <- "false", output -> isTargetFog)
-        FindEnemy
-        if (!HasTarget) {
-            SetBool (value <- "true", output -> isTargetFog)
+        Sequence {
+            SetBool (value <- "false", output -> isTargetFog)
+            FindEnemy
+            if (!HasTarget) {
+                SetBool (value <- "true", output -> isTargetFog)
+            }
         }
     }
 

--- a/behavior_tree_config/red/agent.btc
+++ b/behavior_tree_config/red/agent.btc
@@ -30,10 +30,12 @@ tree main = Sequence {
 tree Fight = Sequence {
     var isTargetFog
     Throttle (time <- "100") {
-        SetBool (value <- "false", output -> isTargetFog)
-        FindEnemy
-        if (!HasTarget) {
-            SetBool (value <- "true", output -> isTargetFog)
+        Sequence {
+            SetBool (value <- "false", output -> isTargetFog)
+            FindEnemy
+            if (!HasTarget) {
+                SetBool (value <- "true", output -> isTargetFog)
+            }
         }
     }
 

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -4,12 +4,13 @@ mod syntax_highlighting;
 
 use std::path::Path;
 
+pub(crate) use self::paint_bt::BTComponent;
 use self::syntax_highlighting::{highlight, CodeTheme};
 use crate::{
     app_data::{AppData, BtType},
     bg_image::BgImage,
 };
-use cgmath::Matrix3;
+use cgmath::{Matrix3, Point2, Transform, Vector2};
 use egui::{Color32, Pos2, RichText, Ui};
 use swarm_rs::{
     game::{BoardParams, BoardType, UpdateResult},
@@ -673,4 +674,16 @@ impl eframe::App for SwarmRsApp {
             self.paint_game(ui);
         });
     }
+}
+
+/// Transform a vector (delta). Equivalent to `(m * v.extend(0.)).truncate()`.
+fn _transform_vector(m: &Matrix3<f64>, v: impl Into<Vector2<f64>>) -> Vector2<f64> {
+    // Transform trait is implemented for both Point2 and Point3, so we need to repeat fully qualified method call
+    <Matrix3<f64> as Transform<Point2<f64>>>::transform_vector(m, v.into())
+}
+
+/// Transform a point. Equivalent to `(m * v.extend(1.)).truncate()`.
+fn transform_point(m: &Matrix3<f64>, v: impl Into<Point2<f64>>) -> Point2<f64> {
+    // I don't really get the point of having the vector and the point as different types.
+    <Matrix3<f64> as Transform<Point2<f64>>>::transform_point(m, v.into())
 }

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -4,7 +4,7 @@ mod syntax_highlighting;
 
 use std::path::Path;
 
-pub(crate) use self::paint_bt::BTComponent;
+pub(crate) use self::paint_bt::BTWidget;
 use self::syntax_highlighting::{highlight, CodeTheme};
 use crate::{
     app_data::{AppData, BtType},

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -166,10 +166,14 @@ impl SwarmRsApp {
     }
 
     fn show_panel_ui(&mut self, ui: &mut Ui) {
-        ui.add(egui::Checkbox::new(
-            &mut self.app_data.game_params.paused,
-            "Paused",
-        ));
+        ui.horizontal(|ui| {
+            ui.add(egui::Checkbox::new(
+                &mut self.app_data.game_params.paused,
+                "Paused",
+            ));
+
+            ui.checkbox(&mut self.app_data.bt_visible, "BT Graphical editor");
+        });
 
         ui.collapsing("New game options", |ui| {
             if ui.button("New game").clicked() {
@@ -415,18 +419,22 @@ impl SwarmRsApp {
     fn show_editor(&mut self, ui: &mut Ui) {
         let team_colors = [Color32::GREEN, Color32::RED];
 
-        if ui.button("Reset all").clicked() {
-            self.app_data.set_confirm_message(
-                "Are you sure you want to reset all the source codes?".to_string(),
-                Box::new(|app_data| {
-                    if let Some(ref mut vfs) = app_data.vfs {
-                        if let Err(e) = vfs.reset() {
-                            app_data.set_message(e);
+        ui.horizontal(|ui| {
+            if ui.button("Reset all").clicked() {
+                self.app_data.set_confirm_message(
+                    "Are you sure you want to reset all the source codes?".to_string(),
+                    Box::new(|app_data| {
+                        if let Some(ref mut vfs) = app_data.vfs {
+                            if let Err(e) = vfs.reset() {
+                                app_data.set_message(e);
+                            }
                         }
-                    }
-                }),
-            )
-        }
+                    }),
+                )
+            }
+
+            ui.checkbox(&mut self.app_data.bt_visible, "BT Graphical editor");
+        });
 
         ui.horizontal(|ui| {
             ui.label("BT to apply:");
@@ -664,11 +672,13 @@ impl eframe::App for SwarmRsApp {
             }
         });
 
-        egui::TopBottomPanel::bottom("bt_graph")
-            .resizable(true)
-            .show(ctx, |ui| {
-                self.paint_bt(ui);
-            });
+        if self.app_data.bt_visible {
+            egui::TopBottomPanel::bottom("bt_graph")
+                .resizable(true)
+                .show(ctx, |ui| {
+                    self.paint_bt(ui);
+                });
+        }
 
         egui::CentralPanel::default().show(ctx, |ui| {
             self.paint_game(ui);

--- a/eframe/src/app.rs
+++ b/eframe/src/app.rs
@@ -1,3 +1,4 @@
+mod paint_bt;
 mod paint_game;
 mod syntax_highlighting;
 
@@ -661,6 +662,12 @@ impl eframe::App for SwarmRsApp {
                 Panel::BTEditor => self.show_editor(ui),
             }
         });
+
+        egui::TopBottomPanel::bottom("bt_graph")
+            .resizable(true)
+            .show(ctx, |ui| {
+                self.paint_bt(ui);
+            });
 
         egui::CentralPanel::default().show(ctx, |ui| {
             self.paint_game(ui);

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -260,7 +260,11 @@ impl<'p> NodePainter<'p> {
             .map(|port| {
                 let port_type = port.get_type();
                 let port_galley = self.painter.layout_no_wrap(
-                    port.node_port().to_string(),
+                    if let BlackboardValue::Literal(lit) = port.blackboard_value() {
+                        format!("{} <- {:?}", port.node_port().to_string(), lit)
+                    } else {
+                        port.node_port().to_string()
+                    },
                     self.port_font.clone(),
                     match port_type {
                         PortType::Input => Color32::from_rgb(255, 255, 127),
@@ -269,6 +273,7 @@ impl<'p> NodePainter<'p> {
                     },
                 );
                 let port_height = port_galley.size().y;
+                let port_width = port_galley.size().x;
                 let ret = (port_galley, y, port_type);
 
                 if let BlackboardValue::Ref(bbref) = port.blackboard_value() {
@@ -284,6 +289,8 @@ impl<'p> NodePainter<'p> {
                         _ => (),
                     }
                 }
+
+                size.x = size.x.max(port_width);
 
                 y += port_height;
                 ret
@@ -360,7 +367,7 @@ impl<'p> NodePainter<'p> {
             self.painter.line_segment([from, to], (2., Color32::YELLOW));
         }
 
-        size.x = tree_width;
+        size.x = size.x.max(tree_width);
 
         size
     }

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -1,6 +1,6 @@
 use eframe::emath::RectTransform;
 use egui::{pos2, Color32, FontId, Frame, Painter, Pos2, Rect, Ui, Vec2};
-use swarm_rs::behavior_tree_lite::{parse_file, parser::TreeDef};
+use swarm_rs::behavior_tree_lite::{parse_file, parser::TreeDef, PortType};
 
 use crate::SwarmRsApp;
 
@@ -26,13 +26,7 @@ impl SwarmRsApp {
                 return;
             };
 
-            let font = FontId::monospace(16.);
-
-            let node_painter = NodePainter {
-                painter: &painter,
-                font,
-                to_screen: &to_screen,
-            };
+            let node_painter = NodePainter::new(&painter, &to_screen);
 
             node_painter.paint_node_recurse(NODE_PADDING, NODE_PADDING, &main.root());
         });
@@ -48,13 +42,24 @@ const NODE_SPACING: f32 = 20.;
 
 struct NodePainter<'p> {
     painter: &'p Painter,
-    font: FontId,
     to_screen: &'p RectTransform,
+    font: FontId,
+    port_font: FontId,
 }
 
 impl<'p> NodePainter<'p> {
-    fn paint_node_recurse(&self, mut x: f32, y: f32, node: &TreeDef<'_>) -> Vec2 {
+    fn new(painter: &'p Painter, to_screen: &'p RectTransform) -> Self {
+        Self {
+            painter,
+            to_screen,
+            font: FontId::monospace(16.),
+            port_font: FontId::monospace(12.),
+        }
+    }
+
+    fn paint_node_recurse(&self, mut x: f32, mut y: f32, node: &TreeDef<'_>) -> Vec2 {
         let initial_x = x;
+        let initial_y = y;
         let galley = self.painter.layout_no_wrap(
             node.get_type().to_string(),
             self.font.clone(),
@@ -80,13 +85,31 @@ impl<'p> NodePainter<'p> {
         let tree_width = size.x.max(x - initial_x - NODE_PADDING2 - NODE_SPACING);
         let node_left = initial_x + (tree_width - size.x) / 2.;
 
+        y += size.y + NODE_PADDING;
+        let ports: Vec<_> = node
+            .port_maps()
+            .iter()
+            .map(|port| {
+                let port_galley = self.painter.layout_no_wrap(
+                    port.node_port().to_string(),
+                    self.port_font.clone(),
+                    match port.get_type() {
+                        PortType::Input => Color32::from_rgb(255, 255, 127),
+                        PortType::Output => Color32::from_rgb(127, 255, 255),
+                        PortType::InOut => Color32::from_rgb(127, 255, 127),
+                    },
+                );
+                let port_height = port_galley.size().y;
+                let port = (port_galley, y);
+                y += port_height;
+                port
+            })
+            .collect();
+
         self.painter.rect(
             self.to_screen.transform_rect(Rect {
-                min: pos2(node_left, y),
-                max: pos2(
-                    node_left + NODE_PADDING2 + size.x,
-                    y + NODE_PADDING2 + size.y,
-                ),
+                min: pos2(node_left, initial_y),
+                max: pos2(node_left + NODE_PADDING2 + size.x, y + NODE_PADDING),
             }),
             0.,
             Color32::from_rgb(63, 63, 31),
@@ -95,13 +118,21 @@ impl<'p> NodePainter<'p> {
 
         self.painter.galley(
             self.to_screen
-                .transform_pos(pos2(node_left + NODE_PADDING, y + NODE_PADDING)),
+                .transform_pos(pos2(node_left + NODE_PADDING, initial_y + NODE_PADDING)),
             galley,
         );
 
+        for (port, y) in ports {
+            self.painter.galley(
+                self.to_screen
+                    .transform_pos(pos2(node_left + NODE_PADDING, y)),
+                port,
+            );
+        }
+
         let from = self
             .to_screen
-            .transform_pos(pos2(node_left + size.x / 2., y + size.y + NODE_PADDING2));
+            .transform_pos(pos2(node_left + size.x / 2., y + NODE_PADDING));
         for to in subnode_connectors {
             self.painter.line_segment([from, to], (2., Color32::YELLOW));
         }

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -72,12 +72,12 @@ impl SwarmRsApp {
             ui.group(|ui| {
                 for tree in &trees.tree_defs {
                     let mut tree_name = RichText::new(tree.name());
-                    if self.app_data.bt_compo.tree == tree.name() {
+                    if self.app_data.bt_widget.tree == tree.name() {
                         // TODO: use black in light theme
                         tree_name = tree_name.underline().color(Color32::WHITE);
                     }
                     if ui.label(tree_name).interact(egui::Sense::click()).clicked() {
-                        self.app_data.bt_compo.tree = tree.name().to_owned();
+                        self.app_data.bt_widget.tree = tree.name().to_owned();
                     }
                 }
             });
@@ -86,17 +86,17 @@ impl SwarmRsApp {
         ui.horizontal(|ui| {
             ui.label("Font size:");
             ui.radio_value(
-                &mut self.app_data.bt_compo.font_size,
+                &mut self.app_data.bt_widget.font_size,
                 FontSize::Small,
                 "Small",
             );
             ui.radio_value(
-                &mut self.app_data.bt_compo.font_size,
+                &mut self.app_data.bt_widget.font_size,
                 FontSize::Normal,
                 "Normal",
             );
             ui.radio_value(
-                &mut self.app_data.bt_compo.font_size,
+                &mut self.app_data.bt_widget.font_size,
                 FontSize::Large,
                 "Large",
             );
@@ -106,8 +106,8 @@ impl SwarmRsApp {
             let (response, painter) =
                 ui.allocate_painter(ui.available_size(), egui::Sense::hover());
 
-            self.app_data.bt_compo.canvas_offset = response.rect.min;
-            self.app_data.bt_compo.scale = match self.app_data.bt_compo.font_size {
+            self.app_data.bt_widget.canvas_offset = response.rect.min;
+            self.app_data.bt_widget.scale = match self.app_data.bt_widget.font_size {
                 FontSize::Small => 0.7,
                 FontSize::Normal => 1.,
                 FontSize::Large => 1.5,
@@ -118,14 +118,14 @@ impl SwarmRsApp {
                 response.rect,
             );
 
-            let Some(main) = trees.tree_defs.iter().find(|node| node.name() == self.app_data.bt_compo.tree) else {
-                println!("No tree {main:?} defined in {tree:?}", main = self.app_data.bt_compo.tree, tree = trees.tree_defs.iter().map(|node| node.name()).collect::<Vec<_>>());
+            let Some(main) = trees.tree_defs.iter().find(|node| node.name() == self.app_data.bt_widget.tree) else {
+                println!("No tree {main:?} defined in {tree:?}", main = self.app_data.bt_widget.tree, tree = trees.tree_defs.iter().map(|node| node.name()).collect::<Vec<_>>());
                 return;
             };
 
-            let mut node_painter = NodePainter::new(&self.app_data.bt_compo, &painter, &to_screen);
+            let mut node_painter = NodePainter::new(&self.app_data.bt_widget, &painter, &to_screen);
 
-            let scale = self.app_data.bt_compo.scale as f32;
+            let scale = self.app_data.bt_widget.scale as f32;
             node_painter.paint_node_recurse(NODE_PADDING * scale, NODE_PADDING * scale, &main.root());
 
             node_painter.render_connections();
@@ -154,8 +154,8 @@ impl SwarmRsApp {
                 // }
 
                 if ui_result.pointer {
-                    self.app_data.bt_compo.origin[0] += ui_result.delta[0] as f64; // self.app_data.bt_compo.scale;
-                    self.app_data.bt_compo.origin[1] += ui_result.delta[1] as f64; // self.app_data.bt_compo.scale;
+                    self.app_data.bt_widget.origin[0] += ui_result.delta[0] as f64; // self.app_data.bt_compo.scale;
+                    self.app_data.bt_widget.origin[1] += ui_result.delta[1] as f64; // self.app_data.bt_compo.scale;
                 }
             }
         });

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -1,0 +1,113 @@
+use eframe::emath::RectTransform;
+use egui::{pos2, Color32, FontId, Frame, Painter, Pos2, Rect, Ui, Vec2};
+use swarm_rs::behavior_tree_lite::{parse_file, parser::TreeDef};
+
+use crate::SwarmRsApp;
+
+impl SwarmRsApp {
+    pub(crate) fn paint_bt(&mut self, ui: &mut Ui) {
+        Frame::canvas(ui.style()).show(ui, |ui| {
+            let (response, painter) =
+                ui.allocate_painter(ui.available_size(), egui::Sense::hover());
+
+            let to_screen = egui::emath::RectTransform::from_to(
+                Rect::from_min_size(Pos2::ZERO, response.rect.size()),
+                response.rect,
+            );
+
+            let source = &mut self.app_data.bt_buffer;
+            let Ok((_, tree)) = parse_file(source) else {
+                println!("Error on parsing source");
+                return;
+            };
+
+            let Some(main) = tree.tree_defs.iter().find(|node| node.name() == "main") else {
+                println!("No main tree defined in {:?}", tree.tree_defs.iter().map(|node| node.name()).collect::<Vec<_>>());
+                return;
+            };
+
+            let font = FontId::monospace(16.);
+
+            let node_painter = NodePainter {
+                painter: &painter,
+                font,
+                to_screen: &to_screen,
+            };
+
+            node_painter.paint_node_recurse(NODE_PADDING, NODE_PADDING, &main.root());
+        });
+    }
+}
+
+/// Padding in one side
+const NODE_PADDING: f32 = 5.;
+/// Padding in both sides
+const NODE_PADDING2: f32 = NODE_PADDING * 2.;
+/// Space between node rectangles
+const NODE_SPACING: f32 = 20.;
+
+struct NodePainter<'p> {
+    painter: &'p Painter,
+    font: FontId,
+    to_screen: &'p RectTransform,
+}
+
+impl<'p> NodePainter<'p> {
+    fn paint_node_recurse(&self, mut x: f32, y: f32, node: &TreeDef<'_>) -> Vec2 {
+        let initial_x = x;
+        let galley = self.painter.layout_no_wrap(
+            node.get_type().to_string(),
+            self.font.clone(),
+            Color32::WHITE,
+        );
+
+        let mut size = galley.size();
+
+        let mut subnode_connectors = vec![];
+        for child in node.children() {
+            let node_size =
+                self.paint_node_recurse(x, y + size.y + NODE_PADDING2 + NODE_SPACING, child);
+
+            let to = self.to_screen.transform_pos(pos2(
+                x + node_size.x / 2.,
+                y + size.y + NODE_PADDING2 + NODE_SPACING,
+            ));
+            subnode_connectors.push(to);
+
+            x += node_size.x + NODE_PADDING2 + NODE_SPACING;
+        }
+
+        let tree_width = size.x.max(x - initial_x - NODE_PADDING2 - NODE_SPACING);
+        let node_left = initial_x + (tree_width - size.x) / 2.;
+
+        self.painter.rect(
+            self.to_screen.transform_rect(Rect {
+                min: pos2(node_left, y),
+                max: pos2(
+                    node_left + NODE_PADDING2 + size.x,
+                    y + NODE_PADDING2 + size.y,
+                ),
+            }),
+            0.,
+            Color32::from_rgb(63, 63, 31),
+            (1., Color32::from_rgb(127, 127, 191)),
+        );
+
+        self.painter.galley(
+            self.to_screen
+                .transform_pos(pos2(node_left + NODE_PADDING, y + NODE_PADDING)),
+            galley,
+        );
+
+        let from = self
+            .to_screen
+            .transform_pos(pos2(node_left + size.x / 2., y + size.y + NODE_PADDING2));
+        for to in subnode_connectors {
+            self.painter.line_segment([from, to], (2., Color32::YELLOW));
+        }
+
+        size.x = tree_width;
+
+        size
+    }
+}

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -371,10 +371,37 @@ impl<'p> NodePainter<'p> {
                 for dest in &con.dest {
                     let from = self.to_pos2(*source);
                     let to = self.to_pos2(*dest);
-                    self.painter
-                        .line_segment([from, to], (2., Color32::from_rgb(255, 127, 255)));
+                    let mut points = vec![];
+                    let midpoint = ((from.to_vec2() + to.to_vec2()) / 2.).to_pos2();
+                    let cp_length =
+                        ((to.x - from.x) / 2.).min(100. * self.bt_component.scale as f32);
+                    let from_cp = from + vec2(cp_length, 0.);
+                    let to_cp = to + vec2(-cp_length, 0.);
+                    let interpolates = 10;
+                    for i in 0..=interpolates {
+                        let f = i as f32 / interpolates as f32;
+                        let p0 = interp(from, from_cp, f);
+                        let p1 = interp(from_cp, midpoint, f);
+                        let p2 = interp(p0, p1, f);
+                        points.push(p2);
+                    }
+                    for i in 0..=interpolates {
+                        let f = i as f32 / interpolates as f32;
+                        let p0 = interp(midpoint, to_cp, f);
+                        let p1 = interp(to_cp, to, f);
+                        let p2 = interp(p0, p1, f);
+                        points.push(p2);
+                    }
+                    self.painter.add(PathShape::line(
+                        points,
+                        (2., Color32::from_rgb(255, 127, 255)),
+                    ));
                 }
             }
         }
     }
+}
+
+fn interp(v0: Pos2, v1: Pos2, f: f32) -> Pos2 {
+    (v0.to_vec2() * (1. - f) + v1.to_vec2() * f).to_pos2()
 }

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -15,19 +15,7 @@ use swarm_rs::{
     Bullet, CellState,
 };
 
-use super::SwarmRsApp;
-
-/// Transform a vector (delta). Equivalent to `(m * v.extend(0.)).truncate()`.
-fn _transform_vector(m: &Matrix3<f64>, v: impl Into<Vector2<f64>>) -> Vector2<f64> {
-    // Transform trait is implemented for both Point2 and Point3, so we need to repeat fully qualified method call
-    <Matrix3<f64> as Transform<Point2<f64>>>::transform_vector(m, v.into())
-}
-
-/// Transform a point. Equivalent to `(m * v.extend(1.)).truncate()`.
-fn transform_point(m: &Matrix3<f64>, v: impl Into<Point2<f64>>) -> Point2<f64> {
-    // I don't really get the point of having the vector and the point as different types.
-    <Matrix3<f64> as Transform<Point2<f64>>>::transform_point(m, v.into())
-}
+use super::{transform_point, SwarmRsApp};
 
 /// In points
 const SCREEN_SELECT_RADIUS: f64 = 20.;

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 use crate::app_data::AppData;
-use cgmath::{InnerSpace, Matrix2, Matrix3, MetricSpace, Point2, Rad, Transform, Vector2};
+use cgmath::{InnerSpace, Matrix2, Matrix3, MetricSpace, Point2, Rad, Vector2};
 use eframe::{
     emath::RectTransform,
     epaint::{self, PathShape},

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -85,7 +85,8 @@ pub struct AppData {
     pub(crate) dirty: bool,
     pub(crate) vfs: Option<Box<dyn Vfs>>,
 
-    pub(crate) bt_compo: BTWidget,
+    pub(crate) bt_visible: bool,
+    pub(crate) bt_widget: BTWidget,
 }
 
 impl AppData {
@@ -159,7 +160,8 @@ impl AppData {
             dirty: false,
             vfs: Some(Box::new(vfs)),
 
-            bt_compo: BTWidget::new(),
+            bt_visible: false,
+            bt_widget: BTWidget::new(),
         }
     }
 

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -11,7 +11,7 @@ use swarm_rs::vfs::FileVfs;
 
 use std::rc::Rc;
 
-use crate::app::BTComponent;
+use crate::app::BTWidget;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BtType {
@@ -85,7 +85,7 @@ pub struct AppData {
     pub(crate) dirty: bool,
     pub(crate) vfs: Option<Box<dyn Vfs>>,
 
-    pub(crate) bt_compo: BTComponent,
+    pub(crate) bt_compo: BTWidget,
 }
 
 impl AppData {
@@ -159,7 +159,7 @@ impl AppData {
             dirty: false,
             vfs: Some(Box::new(vfs)),
 
-            bt_compo: BTComponent::new(),
+            bt_compo: BTWidget::new(),
         }
     }
 

--- a/eframe/src/app_data.rs
+++ b/eframe/src/app_data.rs
@@ -11,6 +11,8 @@ use swarm_rs::vfs::FileVfs;
 
 use std::rc::Rc;
 
+use crate::app::BTComponent;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BtType {
     Agent,
@@ -82,6 +84,8 @@ pub struct AppData {
     pub(crate) bt_buffer: String,
     pub(crate) dirty: bool,
     pub(crate) vfs: Option<Box<dyn Vfs>>,
+
+    pub(crate) bt_compo: BTComponent,
 }
 
 impl AppData {
@@ -154,6 +158,8 @@ impl AppData {
             bt_buffer: "".to_owned(),
             dirty: false,
             vfs: Some(Box::new(vfs)),
+
+            bt_compo: BTComponent::new(),
         }
     }
 

--- a/src/behavior_tree_adapt.rs
+++ b/src/behavior_tree_adapt.rs
@@ -1,14 +1,14 @@
 //! An adapter functions and types for behavior_tree_lite
 
 use behavior_tree_lite::{
-    boxify, tick_child_node, BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult,
-    PortSpec, Registry,
+    boxify, BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult,
+    NumChildren, PortSpec, Registry,
 };
 
 use crate::qtree::QTreePathNode;
 
 /// Boundary to skip Debug trait from propagating to BehaviorNode trait
-pub(super) struct BehaviorTree(pub Box<dyn BehaviorNode>);
+pub(super) struct BehaviorTree(pub BehaviorNodeContainer);
 
 impl std::fmt::Debug for BehaviorTree {
     fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -184,7 +184,6 @@ impl BehaviorNode for GetResource {
 #[derive(Default)]
 struct ThrottleNode {
     timer: Option<usize>,
-    child: Option<BehaviorNodeContainer>,
 }
 
 impl BehaviorNode for ThrottleNode {
@@ -210,11 +209,7 @@ impl BehaviorNode for ThrottleNode {
             if *remaining == 0 {
                 // println!("Timed out");
                 set_timer(self);
-                let res = self
-                    .child
-                    .as_mut()
-                    .map(|child| tick_child_node(arg, ctx, child))
-                    .unwrap_or(BehaviorResult::Fail);
+                let res = ctx.tick_child(0, arg).unwrap_or(BehaviorResult::Fail);
                 return res;
             } else {
                 *remaining -= 1;
@@ -226,12 +221,7 @@ impl BehaviorNode for ThrottleNode {
         BehaviorResult::Success
     }
 
-    fn add_child(
-        &mut self,
-        node: Box<dyn BehaviorNode>,
-        blackboard_map: behavior_tree_lite::BBMap,
-    ) -> behavior_tree_lite::error::AddChildResult {
-        self.child = Some(BehaviorNodeContainer::new(node, blackboard_map));
-        Ok(())
+    fn num_children(&self) -> NumChildren {
+        NumChildren::Finite(1)
     }
 }

--- a/src/behavior_tree_adapt.rs
+++ b/src/behavior_tree_adapt.rs
@@ -1,8 +1,8 @@
 //! An adapter functions and types for behavior_tree_lite
 
 use behavior_tree_lite::{
-    boxify, BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult,
-    NumChildren, PortSpec, Registry,
+    boxify, BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult, NumChildren,
+    PortSpec, Registry,
 };
 
 use crate::qtree::QTreePathNode;

--- a/src/behavior_tree_adapt.rs
+++ b/src/behavior_tree_adapt.rs
@@ -221,7 +221,7 @@ impl BehaviorNode for ThrottleNode {
         BehaviorResult::Success
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }


### PR DESCRIPTION
Now we have a graphical editor!

![image](https://user-images.githubusercontent.com/2798715/229337120-7edff8a0-2c50-4d11-ac76-5ab8dc1ebbe0.png)

Actually, it only shows the tree, does not allow you to edit it.

# Port connections

We visualize the port connections if some ports of the nodes in a subtree have the same blackboard variable.

![image](https://user-images.githubusercontent.com/2798715/229339724-3f8dd4a4-3973-49ba-b6a2-df24b32ca8f1.png)

In this particular example, the connections are generated from the `resource` blackboard variable in the textual form.

![image](https://user-images.githubusercontent.com/2798715/229339776-b0dac1c0-bbe7-43c6-b050-616c26815e06.png)

And the connection line is Bezier interpolated.

![image](https://user-images.githubusercontent.com/2798715/229358556-642ddf80-214a-44a2-b676-d8091f99ad32.png)

And now you can toggle the variable name labels. It can be toggled with a checkbox because it can get in the way of other nodes below. I plan to implement some smart arrangement algorithm to avoid overlapping, but not in this PR.

![image](https://user-images.githubusercontent.com/2798715/230445775-1b000171-7967-4e90-bdf0-0f0a5534007c.png)


## Subtree selector

Now you can select a subtree from the list at the top of the BT editor panel.

![image](https://user-images.githubusercontent.com/2798715/229351367-7a8b83bc-f86d-4414-9a33-897f358be978.png)
