### PR TITLE
Behavior tree visual inspector/debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "behavior-tree-lite"
 version = "0.3.0"
-source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?branch=inspect-tree#ff5201ba194c985cdb925c8ac0845c5a5a3c46c1"
+source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?branch=inspect-tree#128958e6f0b86ab09b4c7ab5f12e4a54248dc98c"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,8 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "behavior-tree-lite"
-version = "0.3.0"
-source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?branch=inspect-tree#128958e6f0b86ab09b4c7ab5f12e4a54248dc98c"
+version = "0.3.1"
+source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.3.1#5da09b5e1fd2dbe4a0569ad551fde8a76c57b1ac"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "behavior-tree-lite"
 version = "0.3.0"
-source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?tag=v0.3.0#9ecd1071ece77512d3096a36a1b4cf828c5680d5"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 [[package]]
 name = "behavior-tree-lite"
 version = "0.3.0"
+source = "git+https://github.com/msakuta/rusty-behavior-tree-lite?branch=inspect-tree#ff5201ba194c985cdb925c8ac0845c5a5a3c46c1"
 dependencies = [
  "nom",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,8 @@ getrandom = { version = "0.2.8", features = ["js"] }
 [dependencies.behavior-tree-lite]
 # path = "../rusty-behavior-tree-lite"
 git = "https://github.com/msakuta/rusty-behavior-tree-lite"
-# tag = "v0.3.0"
+tag = "v0.3.1"
 # commit = "ff5201ba194c985cdb925c8ac0845c5a5a3c46c1"
-branch = "inspect-tree"
 
 [features]
 druid = [ "dep:druid" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2.8", features = ["js"] }
 
 [dependencies.behavior-tree-lite]
-path = "../rusty-behavior-tree-lite"
-# git = "https://github.com/msakuta/rusty-behavior-tree-lite"
+# path = "../rusty-behavior-tree-lite"
+git = "https://github.com/msakuta/rusty-behavior-tree-lite"
 # tag = "v0.3.0"
-# commit = "96559722c23d7a637879192f635a785b071d6fb1"
-# branch = "master"
+# commit = "ff5201ba194c985cdb925c8ac0845c5a5a3c46c1"
+branch = "inspect-tree"
 
 [features]
 druid = [ "dep:druid" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 getrandom = { version = "0.2.8", features = ["js"] }
 
 [dependencies.behavior-tree-lite]
-# path = "../rusty-behavior-tree-lite"
-git = "https://github.com/msakuta/rusty-behavior-tree-lite"
-tag = "v0.3.0"
+path = "../rusty-behavior-tree-lite"
+# git = "https://github.com/msakuta/rusty-behavior-tree-lite"
+# tag = "v0.3.0"
 # commit = "96559722c23d7a637879192f635a785b071d6fb1"
 # branch = "master"
 

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -8,7 +8,7 @@ use swarm_rs::{
         parse_file,
         parser::TreeDef,
         parser::{BlackboardValue, PortMap, PortMapOwned},
-        AbstractPortMap, BehaviorNodeContainer, BlackboardValueOwned, PortType, BehaviorResult,
+        AbstractPortMap, BehaviorNodeContainer, BehaviorResult, BlackboardValueOwned, PortType,
     },
     BehaviorTree,
 };

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -74,7 +74,13 @@ impl SwarmRsApp {
                     }
                 })
             }),
-            Panel::BTEditor => Some(Rc::new(self.app_data.bt_buffer.clone())),
+            Panel::BTEditor => {
+                if self.app_data.bt_buffer.is_empty() {
+                    None
+                } else {
+                    Some(Rc::new(self.app_data.bt_buffer.clone()))
+                }
+            }
         };
         let trees = source
             .as_ref()
@@ -96,6 +102,15 @@ impl SwarmRsApp {
                             self.app_data.bt_widget.tree = tree.name().to_owned();
                         }
                     }
+                } else {
+                    match self.open_panel {
+                        Panel::Main => ui.label(
+                            RichText::new("Select an entity to show its behavior trees!")
+                                .font(FontId::proportional(18.0))),
+                        Panel::BTEditor => ui.label(
+                            RichText::new("Select a btc source file or enter source to show its behavior trees!")
+                                .font(FontId::proportional(18.0))),
+                    };
                 }
             });
         });
@@ -142,7 +157,6 @@ impl SwarmRsApp {
             );
 
             let Some(main) = trees.tree_defs.iter().find(|node| node.name() == self.app_data.bt_widget.tree) else {
-                println!("No tree {main:?} defined in {tree:?}", main = self.app_data.bt_widget.tree, tree = trees.tree_defs.iter().map(|node| node.name()).collect::<Vec<_>>());
                 return;
             };
 

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -27,6 +27,7 @@ pub(crate) struct BTWidget {
     pub(crate) canvas_offset: Pos2,
     font_size: FontSize,
     tree: String,
+    show_var_connections: bool,
     /// Whether to show the blackboard variables names on the connections.
     show_vars: bool,
 }
@@ -39,6 +40,7 @@ impl BTWidget {
             canvas_offset: Pos2::ZERO,
             font_size: FontSize::Normal,
             tree: "main".to_string(),
+            show_var_connections: true,
             show_vars: true,
         }
     }
@@ -144,6 +146,10 @@ impl SwarmRsApp {
                 "Large",
             );
             ui.checkbox(
+                &mut self.app_data.bt_widget.show_var_connections,
+                "Show variable connections",
+            );
+            ui.checkbox(
                 &mut self.app_data.bt_widget.show_vars,
                 "Show variable labels",
             );
@@ -157,7 +163,7 @@ impl SwarmRsApp {
 
             self.app_data.bt_widget.canvas_offset = response.rect.min;
             self.app_data.bt_widget.scale = match self.app_data.bt_widget.font_size {
-                FontSize::Small => 0.7,
+                FontSize::Small => 0.3,
                 FontSize::Normal => 1.,
                 FontSize::Large => 1.5,
             };
@@ -181,7 +187,9 @@ impl SwarmRsApp {
             let scale = self.app_data.bt_widget.scale as f32;
             node_painter.paint_node_recurse(NODE_PADDING * scale, NODE_PADDING * scale, &main.0);
 
-            node_painter.render_connections();
+            if self.app_data.bt_widget.show_var_connections {
+                node_painter.render_variable_connections();
+            }
 
             if ui.ui_contains_pointer() {
                 // We disallow changing scale with a mouse wheel, because the font size does not scale linearly.
@@ -547,7 +555,7 @@ impl<'p> NodePainter<'p> {
         size
     }
 
-    fn render_connections(&self) {
+    fn render_variable_connections(&self) {
         for (name, con) in &self.bb_connections {
             for source in &con.source {
                 for dest in &con.dest {

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -714,7 +714,7 @@ impl<'p> NodePainter<'p> {
             Some(BehaviorResult::Success) => Color32::from_rgb(31, 127, 31),
             Some(BehaviorResult::Fail) => Color32::from_rgb(127, 31, 31),
             Some(BehaviorResult::Running) => Color32::from_rgb(127, 127, 31),
-            _ => Color32::from_rgb(63, 63, 31),
+            _ => Color32::from_rgb(31, 31, 95),
         };
         if node.draw_border() {
             self.painter

--- a/eframe/src/app/paint_bt.rs
+++ b/eframe/src/app/paint_bt.rs
@@ -48,10 +48,6 @@ impl BTWidget {
             show_vars: true,
         }
     }
-
-    pub(crate) fn view_transform(&self) -> Matrix3<f64> {
-        Matrix3::from_translation(self.origin.into())
-    }
 }
 
 impl SwarmRsApp {
@@ -204,28 +200,6 @@ impl SwarmRsApp {
             }
 
             if ui.ui_contains_pointer() {
-                // We disallow changing scale with a mouse wheel, because the font size does not scale linearly.
-                // if ui_result.scroll_delta != 0. || ui_result.zoom_delta != 1. {
-                //     let old_offset = transform_point(
-                //         &self.app_data.bt_compo.inverse_view_transform(),
-                //         ui_result.interact_pos,
-                //     );
-                //     if ui_result.scroll_delta < 0. {
-                //         self.app_data.bt_compo.scale /= 1.2;
-                //     } else if 0. < ui_result.scroll_delta {
-                //         self.app_data.bt_compo.scale *= 1.2;
-                //     } else if ui_result.zoom_delta != 1. {
-                //         self.app_data.bt_compo.scale *= ui_result.zoom_delta as f64;
-                //     }
-                //     let new_offset = transform_point(
-                //         &self.app_data.bt_compo.inverse_view_transform(),
-                //         ui_result.interact_pos,
-                //     );
-                //     let diff = new_offset - old_offset;
-                //     self.app_data.bt_compo.origin =
-                //         (Vector2::<f64>::from(self.app_data.bt_compo.origin) + diff).into();
-                // }
-
                 if ui_result.pointer {
                     self.app_data.bt_widget.origin[0] += ui_result.delta[0] as f64;
                     self.app_data.bt_widget.origin[1] += ui_result.delta[1] as f64;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -35,6 +35,7 @@ use behavior_tree_lite::{error::LoadError, BehaviorResult, Blackboard, Lazy};
 use std::{
     cell::RefCell,
     collections::{HashSet, VecDeque},
+    rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Mutex,
@@ -94,6 +95,7 @@ pub struct Agent {
     pub trace: VecDeque<[f64; 2]>,
     last_motion_result: Option<MotionCommandResult>,
     last_state: Option<AgentState>,
+    behavior_source: Rc<String>,
     behavior_tree: Option<BehaviorTree>,
     blackboard: Blackboard,
     log_buffer: VecDeque<String>,
@@ -122,12 +124,12 @@ impl Agent {
         orient: f64,
         team: usize,
         class: AgentClass,
-        behavior_source: &str,
+        behavior_source: Rc<String>,
     ) -> Result<Self, LoadError> {
         let id = *id_gen;
         *id_gen += 1;
 
-        let (tree, _build_time) = measure_time(|| build_tree(behavior_source));
+        let (tree, _build_time) = measure_time(|| build_tree(&behavior_source));
         let tree = tree?;
         // println!("tree build: {}", build_time);
 
@@ -152,6 +154,7 @@ impl Agent {
             trace: VecDeque::new(),
             last_motion_result: None,
             last_state: None,
+            behavior_source,
             behavior_tree: Some(tree),
             blackboard: Blackboard::new(),
             log_buffer: VecDeque::new(),
@@ -205,6 +208,10 @@ impl Agent {
 
     pub(crate) fn log_buffer(&self) -> &VecDeque<String> {
         &self.log_buffer
+    }
+
+    pub(crate) fn behavior_source(&self) -> Rc<String> {
+        self.behavior_source.clone()
     }
 
     /// Check collision in qtree bounding boxes

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -214,6 +214,10 @@ impl Agent {
         self.behavior_source.clone()
     }
 
+    pub(crate) fn behavior_tree(&self) -> Option<&BehaviorTree> {
+        self.behavior_tree.as_ref()
+    }
+
     /// Check collision in qtree bounding boxes
     pub(crate) fn qtree_collision(
         ignore: Option<usize>,

--- a/src/behavior_tree_adapt.rs
+++ b/src/behavior_tree_adapt.rs
@@ -8,7 +8,7 @@ use behavior_tree_lite::{
 use crate::qtree::QTreePathNode;
 
 /// Boundary to skip Debug trait from propagating to BehaviorNode trait
-pub(super) struct BehaviorTree(pub BehaviorNodeContainer);
+pub struct BehaviorTree(pub BehaviorNodeContainer);
 
 impl std::fmt::Debug for BehaviorTree {
     fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -3,6 +3,7 @@ use cgmath::{InnerSpace, Vector2};
 use crate::{
     agent::Agent,
     agent::{AgentClass, Bullet, PathNode, AGENT_MAX_RESOURCE},
+    behavior_tree_adapt::BehaviorTree,
     collision::CollisionShape,
     game::Game,
     measure_time,
@@ -235,6 +236,13 @@ impl Entity {
         match self {
             Entity::Agent(agent) => agent.behavior_source(),
             Entity::Spawner(spawner) => spawner.behavior_source(),
+        }
+    }
+
+    pub fn behavior_tree(&self) -> Option<&BehaviorTree> {
+        match self {
+            Entity::Agent(agent) => agent.behavior_tree(),
+            _ => None,
         }
     }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -10,7 +10,7 @@ use crate::{
     shape::Idx,
     spawner::{Spawner, SPAWNER_MAX_HEALTH, SPAWNER_MAX_RESOURCE},
 };
-use std::{cell::RefCell, collections::VecDeque};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 pub(crate) const MAX_LOG_ENTRIES: usize = 100;
 
@@ -228,6 +228,13 @@ impl Entity {
         match self {
             Entity::Agent(agent) => agent.log_buffer(),
             Entity::Spawner(spawner) => spawner.log_buffer(),
+        }
+    }
+
+    pub fn behavior_source(&self) -> Rc<String> {
+        match self {
+            Entity::Agent(agent) => agent.behavior_source(),
+            Entity::Spawner(spawner) => spawner.behavior_source(),
         }
     }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -242,7 +242,7 @@ impl Entity {
     pub fn behavior_tree(&self) -> Option<&BehaviorTree> {
         match self {
             Entity::Agent(agent) => agent.behavior_tree(),
-            _ => None,
+            Entity::Spawner(spawner) => spawner.behavior_tree(),
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -434,9 +434,9 @@ impl Game {
                 team,
                 class,
                 if static_ {
-                    STATIC_SOURCE_FILE
+                    Rc::new(STATIC_SOURCE_FILE.to_string())
                 } else {
-                    &self.params.teams[team].agent_source
+                    self.params.teams[team].agent_source.clone()
                 },
             );
             match agent {
@@ -479,7 +479,7 @@ impl Game {
                     &mut self.id_gen,
                     pos_candidate,
                     team,
-                    &self.params.teams[team].spawner_source,
+                    self.params.teams[team].spawner_source.clone(),
                 );
                 match spawner {
                     Ok(spawner) => return Some(Entity::Spawner(spawner)),

--- a/src/game.rs
+++ b/src/game.rs
@@ -874,6 +874,17 @@ impl Game {
                 .collect::<Vec<_>>(),
         ))
     }
+
+    pub fn get_entity(&self, id: usize) -> Option<std::cell::Ref<Entity>> {
+        self.entities.iter().find_map(|entity| {
+            let entity = entity.borrow();
+            if entity.get_id() == id {
+                Some(entity)
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// Separating axis theorem is relatively fast algorithm to detect collision between convex polygons,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod triangle_utils;
 pub mod vfs;
 
 pub use crate::agent::Bullet;
-pub use crate::qtree::CellState;
+pub use crate::{behavior_tree_adapt::BehaviorTree, qtree::CellState};
 pub use behavior_tree_lite;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -83,6 +83,10 @@ impl Spawner {
         self.behavior_source.clone()
     }
 
+    pub(crate) fn behavior_tree(&self) -> Option<&BehaviorTree> {
+        self.behavior_tree.as_ref()
+    }
+
     pub(crate) fn qtree_collision(
         ignore: Option<usize>,
         newpos: SpawnerState,


### PR DESCRIPTION
In #17, We have implemented the feature to visualize the behavior tree config file (not editable yet though), but we also want to use it to inspect running behavior tree in real time.

# Real time state update

In the screenshot below, the green rectangles represent succeeded, red represent failed ones, yellow represent running ones and dark blue represent ones that haven't ticked yet.

![image](https://user-images.githubusercontent.com/2798715/232287431-1aa04902-3835-4122-9dba-6a583fa40b00.png)

It can update the last state dynamically.

https://user-images.githubusercontent.com/2798715/232287657-25b696ce-8d5d-40a5-8d7a-dbbc577b5865.mp4

This required a bit of changes in [behavior-tree-lite](https://github.com/msakuta/rusty-behavior-tree-lite) crate, so now it is bumped to v0.3.1.


# Foldable nodes

The big difference from behavior tree config visualizer and active debugger is that all subtrees are embedded into the main tree, so the tree can be huge and messy (to be fair, part of the reason is that blackboard variables namespaces are not handled correctly, but it would be another PR).

![image](https://user-images.githubusercontent.com/2798715/232287978-9cad2847-0880-4f33-a688-e215faebae3e.png)

I mean, really messy.

![](https://user-images.githubusercontent.com/2798715/230789111-722df0c3-7b5e-4129-a13c-35da02591570.gif)

So we introduce foldable nodes, which are subtree nodes.
Foldable nodes are indicated by double frames and can be expanded/collapsed by clicking.

https://user-images.githubusercontent.com/2798715/232289157-79347d82-c230-4c25-8ba9-55c6f6115854.mp4


# Minimap

Also we introduce a minimap on top right corner of the behavior tree visualizer, in order to mitigate the problem of navigating a huge tree. You can jump to an arbitrary position in the tree by clicking on it.

![image](https://user-images.githubusercontent.com/2798715/232287834-10ce28ea-2e80-4251-9556-a0e3bf6890b5.png)

https://user-images.githubusercontent.com/2798715/232288319-40695e3f-5550-499e-be01-5c5c0870bfd4.mp4


