### PR TITLE
Make Spawners take time to spawn an Entity

### DIFF
--- a/behavior_tree_config/green/spawner.btc
+++ b/behavior_tree_config/green/spawner.btc
@@ -1,4 +1,7 @@
 tree main = Sequence {
+    if (LastSpawnResult(type -> lastType)) {
+        Print(input <- "Spawn{} finished!", arg0 <- lastType)
+    }
     GetResource (output -> resource)
     if (Ge (lhs <- resource, rhs <- "500")) {
         SpawnFighter

--- a/behavior_tree_config/green/spawner.btc
+++ b/behavior_tree_config/green/spawner.btc
@@ -7,4 +7,6 @@ tree main = Sequence {
             SpawnWorker
         }
     }
+    # CurrentSpawnTask(class -> className, remaining_ticks -> remainingTicks)
+    # Print(input <- "class: {}, time: {}", arg0 <- className, arg1 <- remainingTicks)
 }

--- a/behavior_tree_config/green/spawner.btc
+++ b/behavior_tree_config/green/spawner.btc
@@ -9,4 +9,7 @@ tree main = Sequence {
     }
     # CurrentSpawnTask(class -> className, remaining_ticks -> remainingTicks)
     # Print(input <- "class: {}, time: {}", arg0 <- className, arg1 <- remainingTicks)
+    # if (Ge(rhs <- remainingTicks, lhs <- "100")) {
+    #     CancelSpawnTask
+    # }
 }

--- a/behavior_tree_config/red/spawner.btc
+++ b/behavior_tree_config/red/spawner.btc
@@ -1,4 +1,7 @@
 tree main = Sequence {
+    if (LastSpawnResult(type -> lastType)) {
+        Print(input <- "Spawn{} finished!", arg0 <- lastType)
+    }
     GetResource (output -> resource)
     if (Ge (lhs <- resource, rhs <- "500")) {
         SpawnFighter

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -437,9 +437,9 @@ fn paint_real_agent(
         draw_arc(
             painter,
             pos.to_vec2(),
-            12.0,
+            13.,
             progress,
-            (2., Color32::from_rgb(0, 255, 255)),
+            (2., Color32::from_rgb(0, 191, 191)),
         );
     }
 

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -434,7 +434,13 @@ fn paint_real_agent(
 
     if let Entity::Spawner(spawner) = &agent as &Entity {
         let progress = spawner.get_progress();
-        draw_arc(painter, pos.to_vec2(), 12.0, progress, (2., Color32::WHITE));
+        draw_arc(
+            painter,
+            pos.to_vec2(),
+            12.0,
+            progress,
+            (2., Color32::from_rgb(0, 255, 255)),
+        );
     }
 
     let agent_pos = agent.get_pos();

--- a/eframe/src/app/paint_game.rs
+++ b/eframe/src/app/paint_game.rs
@@ -407,24 +407,34 @@ fn paint_real_agent(
         );
     }
 
+    fn draw_arc(
+        painter: &Painter,
+        pos: Vec2,
+        radius: f32,
+        fraction: f32,
+        stroke: impl Into<Stroke> + Copy,
+    ) {
+        use std::f32::consts::PI;
+        let angle = fraction * 2. * PI;
+        let count = (10. * fraction) as i32 + 10; // There is no reason to pick this value, but it seems to work fine.
+        for (i0, i1) in (0..count).zip(1..=count) {
+            let theta0 = i0 as f32 / count as f32 * angle;
+            let theta1 = i1 as f32 / count as f32 * angle;
+            let p0 = Vec2::new(theta0.sin(), -theta0.cos()) * radius + pos;
+            let p1 = Vec2::new(theta1.sin(), -theta1.cos()) * radius + pos;
+            painter.line_segment([p0.to_pos2(), p1.to_pos2()], stroke);
+        }
+    }
+
     let resource = agent.resource();
     if 0 < resource {
-        use std::f64::consts::PI;
-        let f = resource as f64 * 2. * PI / agent.max_resource() as f64;
-        let count = 10; // There is no reason to pick this value, but it seems to work fine.
-        for (i0, i1) in (0..count).zip(1..=count) {
-            let theta0 = (i0 as f64 / count as f64 * f) as f32;
-            let theta1 = (i1 as f64 / count as f64 * f) as f32;
-            let p0 = Vec2::new(theta0.sin(), -theta0.cos()) * 7.5 + pos.to_vec2();
-            let p1 = Vec2::new(theta1.sin(), -theta1.cos()) * 7.5 + pos.to_vec2();
-            painter.line_segment(
-                [p0.to_pos2(), p1.to_pos2()],
-                Stroke {
-                    color: Color32::YELLOW,
-                    width: 2.5,
-                },
-            );
-        }
+        let f = resource as f32 / agent.max_resource() as f32;
+        draw_arc(painter, pos.to_vec2(), 7.5, f, (2.5, Color32::YELLOW));
+    }
+
+    if let Entity::Spawner(spawner) = &agent as &Entity {
+        let progress = spawner.get_progress();
+        draw_arc(painter, pos.to_vec2(), 12.0, progress, (2., Color32::WHITE));
     }
 
     let agent_pos = agent.get_pos();

--- a/src/agent/agent_class.rs
+++ b/src/agent/agent_class.rs
@@ -31,6 +31,13 @@ impl AgentClass {
         }
     }
 
+    pub(crate) fn time(&self) -> usize {
+        match self {
+            Self::Worker => 200,
+            Self::Fighter => 1500,
+        }
+    }
+
     pub(crate) fn health(&self) -> u32 {
         match self {
             Self::Worker => AGENT_MAX_HEALTH,

--- a/src/game.rs
+++ b/src/game.rs
@@ -253,7 +253,6 @@ impl Game {
                 .any(|agent| !agent.borrow().is_agent() && agent.borrow().get_team() == team)
             {
                 let spawner = self.try_new_spawner(team);
-                println!("spawner: {spawner:?}");
                 if let Some(spawner) = spawner {
                     self.entities.push(RefCell::new(spawner));
                 }

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -169,6 +169,10 @@ impl Spawner {
     fn start_spawn(&mut self, class: AgentClass) -> Option<Box<dyn std::any::Any>> {
         if self.spawn_progress.is_none() {
             self.spawn_progress = Some((class.time(), class));
+        } else if let Some((_, cur_class)) = self.spawn_progress {
+            if cur_class != class {
+                self.spawn_progress = Some((class.time(), class));
+            }
         }
         self.spawn_result
             .map(|r| Box::new(r) as Box<dyn std::any::Any>)

--- a/src/spawner/behavior_nodes.rs
+++ b/src/spawner/behavior_nodes.rs
@@ -1,15 +1,19 @@
 use behavior_tree_lite::{
     boxify, error::LoadError, load, parse_file, BehaviorCallback, BehaviorNode, BehaviorResult,
-    Registry,
+    PortSpec, Registry,
 };
 
-use crate::behavior_tree_adapt::{common_tree_nodes, BehaviorTree};
+use crate::{
+    agent::{Agent, AgentClass},
+    behavior_tree_adapt::{common_tree_nodes, BehaviorTree},
+};
 
 pub(super) fn build_tree(source: &str) -> Result<BehaviorTree, LoadError> {
     let mut registry = Registry::default();
     common_tree_nodes(&mut registry);
     registry.register("SpawnFighter", boxify(|| SpawnFighter));
     registry.register("SpawnWorker", boxify(|| SpawnWorker));
+    registry.register("CurrentSpawnTask", boxify(|| CurrentSpawnTask));
 
     let (_i, tree_source) = parse_file(source).unwrap();
     // println!("parse_file rest: {i:?}");
@@ -39,3 +43,35 @@ macro_rules! spawn_impl {
 
 spawn_impl!(SpawnFighter);
 spawn_impl!(SpawnWorker);
+
+pub(super) struct CurrentSpawnTask;
+
+impl BehaviorNode for CurrentSpawnTask {
+    fn provided_ports(&self) -> Vec<behavior_tree_lite::PortSpec> {
+        vec![
+            PortSpec::new_out("class"),
+            PortSpec::new_out("remaining_ticks"),
+        ]
+    }
+
+    fn tick(
+        &mut self,
+        arg: BehaviorCallback,
+        ctx: &mut behavior_tree_lite::Context,
+    ) -> BehaviorResult {
+        let result = arg(self)
+            .and_then(|a| a.downcast_ref::<Option<(usize, AgentClass)>>().copied())
+            .expect("Spawn should return an Option<AgentClass>");
+        ctx.set(
+            "class",
+            result
+                .map(|(_, r)| r.to_string())
+                .unwrap_or_else(|| "None".to_owned()),
+        );
+        ctx.set(
+            "remaining_ticks",
+            result.map(|(r, _)| r as i32).unwrap_or(0),
+        );
+        BehaviorResult::Success
+    }
+}

--- a/src/spawner/behavior_nodes.rs
+++ b/src/spawner/behavior_nodes.rs
@@ -31,8 +31,8 @@ macro_rules! spawn_impl {
                 arg: BehaviorCallback,
                 _ctx: &mut behavior_tree_lite::Context,
             ) -> BehaviorResult {
-                let result = arg(&Self).and_then(|a| a.downcast_ref::<bool>().copied()).expect("Spawn should return a bool");
-                if result {
+                let result = arg(&Self).and_then(|a| a.downcast_ref::<bool>().copied());
+                if result.is_some() {
                     BehaviorResult::Success
                 } else {
                     BehaviorResult::Fail


### PR DESCRIPTION
Right now, spawners spawn entities instantly, given that resources and eitity count cap are not forbidding doing so.
However, this is unrealistic and not so fun, because you could keep a lot of resources in a Spawner and prepare for a counterattack.

Therefore, we introduce a new mechanism to delay creation of Entities from a Spawner.
The delay time values (in ticks) are different among entities types like below.

```
            Self::Worker => 200,
            Self::Fighter => 1500,
```

Spawning a Fighter takes a lot of time, so you would need to prepare them with that in mind.

A spawn task is initiated by one of these behavior nodes:

* `SpawnFighter`
* `SpawnWorker`

A task automatically runs until finish once it is started. You can use `LastSpawnResult` node to get the last result. It yields `Success` when there is a last result and returns which type of entity has been spawned in `type` output port.

# Visualization

While a Spawner is processing a spawn task, its progress arc will be shown:

![spawn-timer](https://user-images.githubusercontent.com/2798715/235474746-6a1605f5-3bf5-458a-89d0-77bdb6241aec.gif)

# Canceling a spawn

You can also cancel a spawn task before it completes.
For example, a behavior tree fragment like below will cancel the spawn task when the remaining tick becomes lower than 100.

```
    CurrentSpawnTask(class -> className, remaining_ticks -> remainingTicks)
    Print(input <- "class: {}, time: {}", arg0 <- className, arg1 <- remainingTicks)
    if (Ge(rhs <- remainingTicks, lhs <- "100")) {
        CancelSpawnTask
    }
```

You could use this to strategically switch the spawning plan.

# Requesting another task while a spawning task is in progress

If you request a spawn task while another is in progress (with a different unit type), the existing one will be canceled and the new task will start over.
Sending a task with the same type does nothing, but it 